### PR TITLE
Only cancel selection when Atom has focus

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "etch": "0.9.0",
-    "fuzzaldrin": "^2.1.0"
+    "fuzzaldrin": "^2.1.0",
+    "sinon": "2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
   "license": "MIT",
   "atomTestRunner": "atom-mocha-test-runner",
   "devDependencies": {
-    "atom-mocha-test-runner": "^0.3.0"
+    "atom-mocha-test-runner": "^0.3.0",
+    "sinon": "^2.1.0"
   },
   "dependencies": {
-    "etch": "0.9.0",
-    "fuzzaldrin": "^2.1.0",
-    "sinon": "2.1.0"
+    "etch": "^0.9.5",
+    "fuzzaldrin": "^2.1.0"
   }
 }

--- a/src/select-list-view.js
+++ b/src/select-list-view.js
@@ -28,7 +28,7 @@ module.exports = class SelectListView {
   didLoseFocus (event) {
     if (this.element.contains(event.relatedTarget)) {
       this.refs.queryEditor.element.focus()
-    } else {
+    } else if (document.hasFocus()) {
       this.cancelSelection()
     }
   }

--- a/test/select-list-view.test.js
+++ b/test/select-list-view.test.js
@@ -3,6 +3,7 @@
 const assert = require('assert')
 const etch = require('etch')
 const sinon = require('sinon')
+const sandbox = sinon.sandbox.create()
 const SelectListView = require('../src/select-list-view')
 
 describe('SelectListView', () => {
@@ -14,6 +15,7 @@ describe('SelectListView', () => {
   })
 
   afterEach(() => {
+    sandbox.restore()
     containerNode.remove()
   })
 
@@ -62,9 +64,14 @@ describe('SelectListView', () => {
     assert.equal(document.activeElement.closest('atom-text-editor'), selectListView.refs.queryEditor.element)
     assert.equal(cancelSelectionEventsCount, 1)
 
-    sinon.stub(document, "hasFocus").callsFake(() => false)
+    const documentHasFocusStub = sandbox.stub(document, "hasFocus")
+    documentHasFocusStub.callsFake(() => false)
     selectListView.refs.queryEditor.element.dispatchEvent(new FocusEvent('blur'))
     assert.equal(cancelSelectionEventsCount, 1)
+
+    documentHasFocusStub.callsFake(() => true)
+    selectListView.refs.queryEditor.element.dispatchEvent(new FocusEvent('blur'))
+    assert.equal(cancelSelectionEventsCount, 2)
   })
 
   it('keyboard navigation and selection', async () => {

--- a/test/select-list-view.test.js
+++ b/test/select-list-view.test.js
@@ -2,6 +2,7 @@
 
 const assert = require('assert')
 const etch = require('etch')
+const sinon = require('sinon')
 const SelectListView = require('../src/select-list-view')
 
 describe('SelectListView', () => {
@@ -59,6 +60,10 @@ describe('SelectListView', () => {
 
     selectListView.refs.items.querySelector('input').focus()
     assert.equal(document.activeElement.closest('atom-text-editor'), selectListView.refs.queryEditor.element)
+    assert.equal(cancelSelectionEventsCount, 1)
+
+    sinon.stub(document, "hasFocus").callsFake(() => false)
+    selectListView.refs.queryEditor.element.dispatchEvent(new FocusEvent('blur'))
     assert.equal(cancelSelectionEventsCount, 1)
   })
 


### PR DESCRIPTION
Re-implementation of https://github.com/atom/atom-space-pen-views/pull/18 to fix https://github.com/atom/atom/issues/1918 again.  I confirmed that this fix works by testing it out on encoding-selector.

Please inform me if I should add a spec.