### PR TITLE
Add repository to manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,5 +16,9 @@
   "dependencies": {
     "etch": "^0.9.5",
     "fuzzaldrin": "^2.1.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/atom/atom-select-list.git"
   }
 }


### PR DESCRIPTION
Useful for when you find this package through npm, and want to look at commit history for changelog and other purposes