### PR TITLE
Slice out maxResults into new array instead of splicing old array.

### DIFF
--- a/src/select-list-view.js
+++ b/src/select-list-view.js
@@ -225,7 +225,7 @@ module.exports = class SelectListView {
       this.items.sort(this.props.order)
     }
     if (this.props.maxResults) {
-      this.items.splice(this.props.maxResults, this.items.length - this.props.maxResults)
+      this.items = this.items.slice(0, this.props.maxResults)
     }
 
     this.selectIndex(0, updateComponent)


### PR DESCRIPTION
This is to fix issue #8.

I used slice here, which is much much faster. The guiding assumption is that if the list is long enough for perf to matter, the maxResults will be much smaller, so a slice makes more sense.

The list now toggles in a few ms, as opposed to a few seconds.