### PR TITLE
Makes auto-selection configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ When creating a new instance of a select list, or when calling `update` on an ex
 * (Optional) `loadingMessage: String`: a string that needs to be set when you are loading items in the background.
 * (Optional) `loadingBadge: String/Number`: a string or number that needs to be set when the progress status changes (e.g. a percentage showing how many items have been loaded so far).
 * (Optional) `itemsClassList: [String]`: an array of strings that will be added as class names to the items element.
+* (Optional) `initialSelectionIndex: Number`: the index of the item to initially select and automatically select after query changes; defaults to 0.
 * (Optional) `didChangeQuery: (query: String) -> Void`: a function that is called when the query changes.
 * (Optional) `didChangeSelection: (item: Object) -> Void`: a function that is called when the selected item changes.
 * (Optional) `didConfirmSelection: (item: Object) -> Void`: a function that is called when the user clicks or presses enter on an item. 

--- a/src/select-list-view.js
+++ b/src/select-list-view.js
@@ -6,6 +6,9 @@ const fuzzaldrin = require('fuzzaldrin')
 module.exports = class SelectListView {
   constructor (props) {
     this.props = props
+    if (!this.props.hasOwnProperty('initialSelectionIndex')) {
+      this.props.initialSelectionIndex = 0
+    }
     this.computeItems(false)
     this.disposables = new CompositeDisposable()
     etch.initialize(this)
@@ -128,6 +131,10 @@ module.exports = class SelectListView {
       this.props.itemsClassList = props.itemsClassList
     }
 
+    if (props.hasOwnProperty('initialSelectionIndex')) {
+      this.props.initialSelectionIndex = props.initialSelectionIndex
+    }
+
     if (shouldComputeItems) {
       this.computeItems()
     }
@@ -231,7 +238,7 @@ module.exports = class SelectListView {
       this.items = this.items.slice(0, this.props.maxResults)
     }
 
-    this.selectIndex(0, updateComponent)
+    this.selectIndex(this.props.initialSelectionIndex, updateComponent)
   }
 
   fuzzyFilter (items, query) {
@@ -252,14 +259,17 @@ module.exports = class SelectListView {
   }
 
   getSelectedItem () {
+    if (this.selectionIndex === undefined) return null
     return this.items[this.selectionIndex]
   }
 
   selectPrevious () {
+    if (this.selectionIndex === undefined) return this.selectLast()
     return this.selectIndex(this.selectionIndex - 1)
   }
 
   selectNext () {
+    if (this.selectionIndex === undefined) return this.selectFirst()
     return this.selectIndex(this.selectionIndex + 1)
   }
 
@@ -271,6 +281,10 @@ module.exports = class SelectListView {
     return this.selectIndex(this.items.length - 1)
   }
 
+  selectNone () {
+    return this.selectIndex(undefined)
+  }
+
   selectIndex (index, updateComponent = true) {
     if (index >= this.items.length) {
       index = 0
@@ -279,7 +293,7 @@ module.exports = class SelectListView {
     }
 
     this.selectionIndex = index
-    if (this.props.didChangeSelection) {
+    if (index !== undefined && this.props.didChangeSelection) {
       this.props.didChangeSelection(this.getSelectedItem())
     }
 


### PR DESCRIPTION
Resolves #10. See the issue for an example use case.

Allows users to chose an initially selected index. This will default to `0`, preserving existing behaviour. Users can override this by setting `initialSelectionIndex` in a call to `update()`. Also this PR addresses issues like:

1. Q: How does the user now select "no items" programmatically? A: `selectNone()`.
2. Q: What does `getSelectedItem()` return in that case? A: `null`.
3. Q: What happens when `selectPrevious()` is called? A: Jump to the end of the list.
4. Q: What happens when `selectNext()` is called? A: Jump to the start of the list.
5. Q: When is `didChangeSelection` triggered? A: Only when there's actually something that is selected. That is, it is NOT called when `getSelectedItem()` would return `null`.