### PR TITLE
Pass options along with item: `selected` and `index`

### DIFF
--- a/src/select-list-view.js
+++ b/src/select-list-view.js
@@ -152,11 +152,15 @@ module.exports = class SelectListView {
       const className = ['list-group'].concat(this.props.itemsClassList || []).join(' ')
       return $.ol(
         {className, ref: 'items'},
-        ...this.items.map((item, index) => $(ListItemView, {
-          element: this.props.elementForItem(item),
-          selected: this.getSelectedItem() === item,
-          onclick: () => this.didClickItem(index)
-        }))
+        ...this.items.map((item, index) => {
+          const selected = this.getSelectedItem() === item
+
+          return $(ListItemView, {
+            element: this.props.elementForItem(item, {selected, index}),
+            selected,
+            onclick: () => this.didClickItem(index)
+          })
+        })
       )
     } else if (!this.props.loadingMessage && this.props.emptyMessage) {
       return $.span({ref: 'emptyMessage'}, this.props.emptyMessage)

--- a/test/select-list-view.test.js
+++ b/test/select-list-view.test.js
@@ -374,7 +374,7 @@ describe('SelectListView', () => {
 
   describe('elementForItem', () => {
     it('passes whether the item is selected', async () => {
-      const elementForItem = sinon.stub().callsFake(() => document.createElement('div'))
+      const elementForItem = sandbox.stub().callsFake(() => document.createElement('div'))
       const selectListView = new SelectListView({
         items: ['foo', 'bar'],
         elementForItem,
@@ -385,7 +385,7 @@ describe('SelectListView', () => {
     })
 
     it('passes the item\'s index', () => {
-      const elementForItem = sinon.stub().callsFake(() => document.createElement('div'))
+      const elementForItem = sandbox.stub().callsFake(() => document.createElement('div'))
       const selectListView = new SelectListView({
         items: ['foo', 'bar'],
         elementForItem,

--- a/test/select-list-view.test.js
+++ b/test/select-list-view.test.js
@@ -371,6 +371,30 @@ describe('SelectListView', () => {
     assert(!selectListView.refs.items.classList.contains('b'))
     assert(selectListView.refs.items.classList.contains('c'))
   })
+
+  describe('elementForItem', () => {
+    it('passes whether the item is selected', async () => {
+      const elementForItem = sinon.stub().callsFake(() => document.createElement('div'))
+      const selectListView = new SelectListView({
+        items: ['foo', 'bar'],
+        elementForItem,
+      })
+
+      assert(elementForItem.calledWithMatch('foo', {selected: true}))
+      assert(elementForItem.calledWithMatch('bar', {selected: false}))
+    })
+
+    it('passes the item\'s index', () => {
+      const elementForItem = sinon.stub().callsFake(() => document.createElement('div'))
+      const selectListView = new SelectListView({
+        items: ['foo', 'bar'],
+        elementForItem,
+      })
+
+      assert(elementForItem.calledWithMatch('foo', {index: 0}))
+      assert(elementForItem.calledWithMatch('bar', {index: 1}))
+    })
+  })
 })
 
 function createElementForItem (item) {


### PR DESCRIPTION
This passes the item's `index` as well as its `selected` state to `elementForItem` callback to help construct meaningful elements.

For example, passing the `selected` state can conditionally show contents without the need for a css selector on the parent element's selected class.