### PR TITLE
fix 15 - mouseUp should recive event parameter

### DIFF
--- a/src/select-list-view.js
+++ b/src/select-list-view.js
@@ -346,7 +346,7 @@ class ListItemView {
     event.preventDefault()
   }
 
-  mouseUp () {
+  mouseUp (event) {
     event.preventDefault()
   }
 


### PR DESCRIPTION
According to #15, there's a missing `event` parameter on `mouseUp` method.
Chromium creates a global window.event, this why you can omit the parameter and do not receive errors.
Font: https://stackoverflow.com/questions/30159017/why-is-event-available-globally-in-chrome-but-not-ff