### PR TITLE
fix #2 - fuzzaldrin-plus

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "etch": "^0.9.5",
-    "fuzzaldrin": "^2.1.0"
+    "fuzzaldrin-plus": "^0.5.0"
   },
   "repository": {
     "type": "git",

--- a/src/select-list-view.js
+++ b/src/select-list-view.js
@@ -1,7 +1,7 @@
 const {Disposable, CompositeDisposable, TextEditor} = require('atom')
 const etch = require('etch')
 const $ = etch.dom
-const fuzzaldrin = require('fuzzaldrin')
+const fuzzaldrin = require('fuzzaldrin-plus')
 const path = require('path')
 
 module.exports = class SelectListView {


### PR DESCRIPTION
This aims to fix issue #2.
As as far as I checked, the difference between `fuzzaldrin` and `fuzzaldrin-plus` is the better result quality. There's no API differences for `score` method, all tests are passing.

@50Wliu Could you please confirm if this resolves the issue?
Thanks.