### PR TITLE
Only render list elements when needed

### DIFF
--- a/src/select-list-view.js
+++ b/src/select-list-view.js
@@ -158,9 +158,8 @@ module.exports = class SelectListView {
     if (this.items.length > 0) {
       if(!this.itemElementsPlain || this.itemElementsPlain && this.itemElementsPlain.size !== this.items.length) {
         this.itemElementsPlain = new Map(this.items.map((item, index) => {
-          const actualIndex = this.items.indexOf(item)
           return [item, $(ListItemView, {
-            element: this.props.elementForItem(item, {selected: false, actualIndex}),
+            element: this.props.elementForItem(item, {selected: false, index}),
             selected: false,
             onclick: () => {
               this.selectItem(item)
@@ -169,9 +168,8 @@ module.exports = class SelectListView {
           })]
         }))
         this.itemElementsSelected = new Map(this.items.map((item, index) => {
-          const actualIndex = this.items.indexOf(item)
           return [item, $(ListItemView, {
-            element: this.props.elementForItem(item, {selected: true, index: actualIndex}),
+            element: this.props.elementForItem(item, {selected: true, index}),
             selected: true,
             onclick: () => {
               this.selectItem(item)

--- a/src/select-list-view.js
+++ b/src/select-list-view.js
@@ -194,9 +194,9 @@ module.exports = class SelectListView {
       )
       return visibleItemElements
     } else if (!this.props.loadingMessage && this.props.emptyMessage) {
-        return $.span({ref: 'emptyMessage'}, this.props.emptyMessage)
+      return $.span({ref: 'emptyMessage'}, this.props.emptyMessage)
     } else {
-        return ""
+      return ""
     }
   }
 

--- a/src/select-list-view.js
+++ b/src/select-list-view.js
@@ -165,7 +165,7 @@ module.exports = class SelectListView {
     }
 
     if (this.itemElements.length > 0) {
-      const margins = 10
+      const margins = 3
       visibleStart = this.selectionIndex - margins
       visibleEnd = this.selectionIndex + margins
       if(visibleStart < 0) {

--- a/src/select-list-view.js
+++ b/src/select-list-view.js
@@ -188,7 +188,6 @@ module.exports = class SelectListView {
         visibleItems = this.items.slice(visibleStart, visibleEnd)
       }
 
-      const scrollType = this.isScrolled? 'auto': 'hidden'
       const style = this.isScrolled? undefined: {'overflow': 'hidden'}
       const onwheel = this.isScrolled? undefined : () => {this.setScroll(true)}
       const visibleItemElements = $.ol(

--- a/src/select-list-view.js
+++ b/src/select-list-view.js
@@ -164,9 +164,10 @@ module.exports = class SelectListView {
       const shouldRenderAhead = !!this.props.renderAheadMargin
       let visibleItems = this.items;
 
+      let visibleStart = 0
       if (shouldRenderAhead) {
         const margins = this.props.renderAheadMargin
-        let visibleStart = this.selectionIndex - margins
+        visibleStart = this.selectionIndex - margins
         let visibleEnd = this.selectionIndex + margins
         if(visibleStart < 0) {
           visibleStart = 0
@@ -181,11 +182,12 @@ module.exports = class SelectListView {
       const visibleItemElements = $.ol(
         {className, ref: 'items', style},
         ...visibleItems.map((item, index) => {
+          const actualIndex = visibleStart + index
           const selected = this.getSelectedItem() === item
           return $(ListItemView, {
             element: this.props.elementForItem(item, {selected, index}),
             selected,
-            onclick: () => this.didClickItem(index)
+            onclick: () => this.didClickItem(actualIndex)
           })
         })
       )

--- a/src/select-list-view.js
+++ b/src/select-list-view.js
@@ -183,10 +183,7 @@ module.exports = class SelectListView {
         ...visibleItems.map((item, index) => {
           const selected = this.getSelectedItem() === item
           return $(ListItemView, {
-            element: this.props.elementForItem(item, {
-              selected,
-              index
-            }),
+            element: this.props.elementForItem(item, {selected, index}),
             selected,
             onclick: () => this.didClickItem(index)
           })

--- a/src/select-list-view.js
+++ b/src/select-list-view.js
@@ -136,6 +136,10 @@ module.exports = class SelectListView {
       this.props.itemsClassList = props.itemsClassList
     }
 
+    if (props.hasOwnProperty('renderAheadMargin')) {
+      this.props.renderAheadMargin = props.renderAheadMargin
+    }
+
     if (shouldComputeItems) {
       this.computeItems()
     }
@@ -157,22 +161,42 @@ module.exports = class SelectListView {
   renderItems () {
     if (this.items.length > 0) {
       const className = ['list-group'].concat(this.props.itemsClassList || []).join(' ')
-      return $.ol(
-        {className, ref: 'items'},
-        ...this.items.map((item, index) => {
-          const selected = this.getSelectedItem() === item
+      const shouldRenderAhead = !!this.props.renderAheadMargin
+      let visibleItems = this.items;
 
+      if (shouldRenderAhead) {
+        const margins = this.props.renderAheadMargin
+        let visibleStart = this.selectionIndex - margins
+        let visibleEnd = this.selectionIndex + margins
+        if(visibleStart < 0) {
+          visibleStart = 0
+        }
+        if(visibleEnd > this.items.length) {
+          visibleEnd = this.items.length
+        }
+        visibleItems = this.items.slice(visibleStart, visibleEnd)
+      }
+
+      const style = shouldRenderAhead? {'overflow':'hidden'}: undefined
+      const visibleItemElements = $.ol(
+        {className, ref: 'items', style},
+        ...visibleItems.map((item, index) => {
+          const selected = this.getSelectedItem() === item
           return $(ListItemView, {
-            element: this.props.elementForItem(item, {selected, index}),
+            element: this.props.elementForItem(item, {
+              selected,
+              index
+            }),
             selected,
             onclick: () => this.didClickItem(index)
           })
         })
       )
+      return visibleItemElements
     } else if (!this.props.loadingMessage && this.props.emptyMessage) {
-      return $.span({ref: 'emptyMessage'}, this.props.emptyMessage)
+        return $.span({ref: 'emptyMessage'}, this.props.emptyMessage)
     } else {
-      return ""
+        return ""
     }
   }
 

--- a/test/select-list-view.test.js
+++ b/test/select-list-view.test.js
@@ -45,7 +45,6 @@ describe('SelectListView', () => {
       element.textContent = `${index}`
       return element
     })
-    const margin = 3 // should match the margin in the SelectListView
 
     const selectListView = new SelectListView({
       items,
@@ -53,26 +52,10 @@ describe('SelectListView', () => {
     })
 
     items.forEach(i => assert(elementForItem.calledWithMatch(i)))
-    elementForItem.reset()
-
-    Array(3*margin).fill('').forEach(async () => await selectListView.selectNext())
-    assert(selectListView.selectionIndex >= 2*margin)
 
     elementForItem.reset()
     await selectListView.selectNext()
-    assert(elementForItem.callCount === (2*margin))
-
-    const firstVisibleIndex = selectListView.selectionIndex - margin
-    const lastVisibleIndex = selectListView.selectionIndex + margin
-
-    const firstItems = items.slice(0, firstVisibleIndex)
-    const middleItems = items.slice(firstVisibleIndex, lastVisibleIndex)
-    const lastItems = items.slice(lastVisibleIndex)
-
-    firstItems.forEach(i => assert(elementForItem.neverCalledWithMatch(i)))
-    middleItems.forEach(i => assert(elementForItem.calledWithMatch(i)))
-    lastItems.forEach(i => assert(elementForItem.neverCalledWithMatch(i)))
-
+    items.forEach(i => assert(elementForItem.neverCalledWithMatch(i)))
   })
 
   it('focus', async () => {


### PR DESCRIPTION
Once a SelectList contains many items, such as in command-palette, scrolling through that list with the keyboard becomes very sluggish. (atom/command-palette/issues/35 and atom/command-palette#80)

This PR changes what items are to be re-rendered. The solution is similar to lazy reloading, where only the items surrounding(including) the currently selected item are asked to refresh by invoking `elementForItem` whenever the selection is changed. Previously, `elementForItem` would be called for all items in the list every time the selection was changed.

With this implementation, all items will initially be cached, and then dynamically updated in that cache when they are within a certain index range of the selected index.