### PR TITLE
Pass visible state to elementForItem + avoid full-render on selectNext/Previous

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ render () {
 When creating a new instance of a select list, or when calling `update` on an existing one, you can supply a JavaScript object that can contain any of the following properties:
 
 * `items: [Object]`: an array containing the objects you want to show in the select list.
-* `elementForItem: (item: Object) -> HTMLElement`: a function that is called whenever an item needs to be displayed. 
+* `elementForItem: (item: Object, options: Object) -> HTMLElement`: a function that is called whenever an item needs to be displayed.
+  * `options: Object`:
+    * `selected: Boolean`: indicating whether item is selected or not.
+    * `index: Number`: item's index.
+    * `visible: Boolean`: indicating whether item is visible in viewport or not. Unless `initiallyVisibleItemCount` was given, this value is always `true`.
 * (Optional) `maxResults: Number`: the number of maximum items that are shown.
 * (Optional) `filter: (items: [Object], query: String) -> [Object]`: a function that allows to decide which items to show whenever the query changes. By default, it uses [fuzzaldrin](https://github.com/atom/fuzzaldrin) to filter results.
 * (Optional) `filterKeyForItem: (item: Object) -> String`: when `filter` is not provided, this function will be called to retrieve a string property on each item and that will be used to filter them.
@@ -46,13 +50,14 @@ When creating a new instance of a select list, or when calling `update` on an ex
 * (Optional) `order: (item1: Object, item2: Object) -> Number`: a function that allows to change the order in which items are shown.
 * (Optional) `emptyMessage: String`: a string shown when the list is empty.
 * (Optional) `errorMessage: String`: a string that needs to be set when you want to notify the user that an error occurred.
-* (Optional) `infoMessage: String`: a string that needs to be set when you want to provide some information to the user. 
+* (Optional) `infoMessage: String`: a string that needs to be set when you want to provide some information to the user.
 * (Optional) `loadingMessage: String`: a string that needs to be set when you are loading items in the background.
 * (Optional) `loadingBadge: String/Number`: a string or number that needs to be set when the progress status changes (e.g. a percentage showing how many items have been loaded so far).
 * (Optional) `itemsClassList: [String]`: an array of strings that will be added as class names to the items element.
 * (Optional) `initialSelectionIndex: Number`: the index of the item to initially select and automatically select after query changes; defaults to 0.
 * (Optional) `didChangeQuery: (query: String) -> Void`: a function that is called when the query changes.
 * (Optional) `didChangeSelection: (item: Object) -> Void`: a function that is called when the selected item changes.
-* (Optional) `didConfirmSelection: (item: Object) -> Void`: a function that is called when the user clicks or presses enter on an item. 
+* (Optional) `didConfirmSelection: (item: Object) -> Void`: a function that is called when the user clicks or presses enter on an item.
 * (Optional) `didConfirmEmptySelection: () -> Void`: a function that is called when the user presses <kbd>Enter</kbd> but the list is empty.
 * (Optional) `didCancelSelection: () -> Void`: a function that is called when the user presses <kbd>Esc</kbd> or the list loses focus.
+* (Optional) `initiallyVisibleItemCount: Number`: When this options was provided, `SelectList` observe visibility of items in viewport, visibility state is passed as `visible` option to `elementForItem`. This is mainly used to skip heavy computation for invisible items.


### PR DESCRIPTION
This is somewhat retry of https://github.com/atom/atom-select-list/pull/21

EDIT at 2017.12.1.

## Main idea

`command-palette:toggle` is not responsive https://github.com/atom/command-palette/pull/81.
To make it faster, we can **skip** full-rendering for invisible items.
To achieve this, this PR newly pass `visible` state as options to `elementForItem`.
Then select-list client(e.g. command-palette) use this information to just return placeholder element instead of render full element.

Following command-palette PR depends on this PR
https://github.com/atom/command-palette/pull/101

## Summary of changes

Summary of changes are also reflected to `README.md`

- When `initiallyVisibleItemCount` prop was set
  - `SelectListView` start checking visibility of item element by `IntersectionObserver` then pass `visible` status to `elementForItem`.
  - When `initiallyVisibleItemCount` was not set, `visible` state is always `true`.
  - To avoid flickering on very first rendering timing, `visible` state for first N items(specified by `initiallyVisibleItemCount`) forcefully set to `true`.
- Make `selectNext`(and it's cousin) update changed items(old and new selected item) only.
  - Old behavior: when selected item was changed, **all** items are recreated by calling `elementForItem` on each items.
  - New behavior: when selected item was changed `elementForItem` is called only for old selected and new selected items only.
    - This skip unnecessary computation and also keep observed element unchanged before and after selected item change.
  - I think this shares same purpose done by https://github.com/atom/command-palette/pull/94
- Performance: following is three times execution of `command-palette:toggle` just after atom-launch.

![slide-picture](https://user-images.githubusercontent.com/155205/33012318-d70a37e8-ce23-11e7-889c-b45bfc7fb24c.jpg)

## Know issue

- When user scroll very fast, they still can see blank item(= fake item).
- You can easily observe it by setting `textContent` to placeholder element
- Since IntersectionObserver detect intersection asynchronously, I believe it's impossible to hide placeholder element completely.


## Check following select-list using package's test still pass

- [x] bookmarks
- [x] command-palette
- [x] encoding-selector
- [x] fuzzy-finder
- [x] git-diff
- [x] grammar-selector
- [x] line-ending-selector
- [x] snippets
- [x] spell-check
- [x] styleguide
- [x] symbols-view
