### PR TITLE
Align selected element to nearest edge while scrolling

### DIFF
--- a/src/select-list-view.js
+++ b/src/select-list-view.js
@@ -388,7 +388,7 @@ class ListItemView {
 
   scrollIntoViewIfNeeded () {
     if (this.selected) {
-      this.element.scrollIntoViewIfNeeded()
+      this.element.scrollIntoViewIfNeeded(false)
     }
   }
 }


### PR DESCRIPTION
This is a very simple fix to make scrolling the list more pleasant and intuitive. I think a visual comparison of the change in behavior describes this change best:

Before: https://i.imgur.com/btUb5gW.gifv

After: https://i.imgur.com/qhMrCLe.gifv

The `selected` item is kept on the boundary while scrolling. This is done by passing `false` to `scrollIntoViewIfNeeded` which otherwise defaults to `true`. 

> [If `false`, the element will be aligned to the nearest edge of the visible area of the scrollable ancestor. Depending on which edge of the visible area is closest to the element, either the top of the element will be aligned to the top edge of the visible area, or the bottom edge of the element will be aligned to the bottom edge of the visible area.](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoViewIfNeeded)

/cc @as-cii 