### PR TITLE
getItemForElement return source item of passed element

### DIFF
--- a/src/select-list-view.js
+++ b/src/select-list-view.js
@@ -311,6 +311,13 @@ module.exports = class SelectListView {
     return this.items[this.selectionIndex]
   }
 
+  getItemForElement (element) {
+    if (element && this.refs.items) {
+      const index = Array.from(this.refs.items.children).indexOf(element)
+      if (index >= 0) return this.items[index]
+    }
+  }
+
   renderItemAtIndex (index) {
     const item = this.items[index]
     const selected = this.getSelectedItem() === item

--- a/test/select-list-view.test.js
+++ b/test/select-list-view.test.js
@@ -548,6 +548,39 @@ describe('SelectListView', () => {
     })
   })
 
+  describe('getItemForElement', () => {
+    it('return source item of passed element', async () => {
+      const selectListView = new SelectListView({
+        items: [{name:'foo'}, {name: 'bar'}, {name: 'baz'}],
+        elementForItem: createElementForItem,
+      })
+      const elements = selectListView.element.querySelectorAll('.item')
+      assert.equal(selectListView.getItemForElement(elements[0]), selectListView.items[0])
+      assert.equal(selectListView.getItemForElement(elements[1]), selectListView.items[1])
+      assert.equal(selectListView.getItemForElement(elements[1]), selectListView.items[1])
+    })
+
+    it('return `undefined` when passed element was not found', async () => {
+      const selectListView = new SelectListView({
+        items: [{name:'foo'}, {name: 'bar'}, {name: 'baz'}],
+        elementForItem: createElementForItem,
+      })
+      const elements = selectListView.element.querySelectorAll('.item')
+      assert.equal(selectListView.getItemForElement(undefined), undefined)
+      assert.equal(selectListView.getItemForElement(null), undefined)
+      assert.equal(selectListView.getItemForElement(false), undefined)
+      assert.equal(selectListView.getItemForElement(document.createElement('li')), undefined)
+    })
+
+    it('does not throw exception when it does not have any items', async () => {
+      const selectListView = new SelectListView({
+        items: [],
+        elementForItem: createElementForItem,
+      })
+      assert.doesNotThrow(() => selectListView.getItemForElement(document.createElement("li")))
+    })
+  })
+
   it('changing and selecting the query', async () => {
     let selectListView = new SelectListView({
       itemsClassList: [], items: [],


### PR DESCRIPTION
I'm working on new PR for command-palette and wanted to get source item from clicked element.
It's achievable by command-palette side by directly accessing `selectListView.refs.children` and `selectListView.items`.

But I think it's reasonable to atom-select-list can answer source item from passed element.
