### PR TITLE
Make element public

### DIFF
--- a/src/select-list-view.ts
+++ b/src/select-list-view.ts
@@ -19,7 +19,7 @@ export default class SelectListView {
   private items: Array<object | string>
 
   private disposables: CompositeDisposable
-  private element: EtchElement
+  public element: EtchElement
   private didClickItemsList: boolean
   private visibilityObserver: IntersectionObserver
   private listItems: any[] | null


### PR DESCRIPTION
### Identify the Bug

With the current code the Readme example:

```
const SelectList = require('atom-select-list')

const usersSelectList = new SelectList({
  items: ['Alice', 'Bob', 'Carol']
})
document.body.appendChild(usersSelectList.element)
```

doesn't work, because `element` is `private`.

### Description of the Change

Making `element` `public`.

### Verification Process

No regression as no functionality removed.

### Release Notes

- The 'element' property is public allowing for its intended use.

